### PR TITLE
Minor dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .project
 velocity.log
 .vagrant
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,13 @@
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
+      <version>2.33.13</version>
     </dependency>
 
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb-enhanced</artifactId>
+      <version>2.33.13</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -106,20 +106,20 @@
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>appbase</artifactId>
-      <version>3.1.11</version>
+      <version>3.1.14</version>
     </dependency>
    
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
         <!-- if your container implements Servlet API older than 3.0, use "jersey-container-servlet-core"  -->
         <artifactId>jersey-container-servlet</artifactId>
-        <version>2.21</version>
+        <version>2.47</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
* Update appbase 3.1.11 -> 3.1.14
* Update jersey-container-servlet 2.21 -> 2.47
* Update javax.servlet-api 3.0.1 -> 3.1.0
* Update .gitignore to ignore .idea directory
* Pinned AWS SDK libs at 2.33.13

NOTE: The pinned version of the AWS libs is based on the resolved version I was seeing in IntelliJ (2.33.4) - I chose to just update to the latest patch release in that series. This PR could possibly update the AWS libraries to the 2.39 series, but I'm not sure of the compatibility of that with the rest of our stack.