### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.epimorphics</groupId>
   <artifactId>armlib</artifactId>
@@ -7,11 +7,19 @@
   <packaging>jar</packaging>
   <name>armlib</name>
   <description>Asynchronous Request Management library</description>
-  
+
   <scm>
     <developerConnection>scm:git:ssh://git@github.com:epimorphics/armlib.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <appbase.version>4.0.0-SNAPSHOT</appbase.version>
+    <jersey.version>3.1.11</jersey.version>
+  </properties>
 
   <repositories>
     <repository>
@@ -20,7 +28,6 @@
       <releases>
         <enabled>true</enabled>
       </releases>
-
     </repository>
 
     <repository>
@@ -33,31 +40,31 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
- 
-    <repository>  
-     <id>epi-public-s3-snapshot</id>  
-     <name>Epimorphics S3 snapshot repository</name>  
-     <url>https://s3-eu-west-1.amazonaws.com/epi-repository/snapshot</url>  
-     <releases>  
-       <enabled>false</enabled>  
-     </releases>  
-     <snapshots>  
-       <enabled>true</enabled>  
-     </snapshots>  
-    </repository>  
 
-    <repository>  
-     <id>epi-public-s3-release</id>  
-     <name>Epimorphics S3 release repository</name>  
-     <url>https://s3-eu-west-1.amazonaws.com/epi-repository/release</url>  
-     <releases>  
-       <enabled>true</enabled>  
-     </releases>  
-     <snapshots>  
-       <enabled>false</enabled>  
-     </snapshots>  
-    </repository>  
-   
+    <repository>
+      <id>epi-public-s3-snapshot</id>
+      <name>Epimorphics S3 snapshot repository</name>
+      <url>https://s3-eu-west-1.amazonaws.com/epi-repository/snapshot</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+
+    <repository>
+      <id>epi-public-s3-release</id>
+      <name>Epimorphics S3 release repository</name>
+      <url>https://s3-eu-west-1.amazonaws.com/epi-repository/release</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+
     <repository>
       <releases>
         <enabled>true</enabled>
@@ -69,20 +76,19 @@
       <name>Epimorphics Public Repository</name>
       <url>https://repository.epimorphics.com</url>
     </repository>
-        
   </repositories>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.33.4</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-</dependencyManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.33.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
@@ -94,58 +100,60 @@
     </dependency>
 
     <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>s3</artifactId>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
       <version>2.33.13</version>
     </dependency>
 
     <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>dynamodb-enhanced</artifactId>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb-enhanced</artifactId>
       <version>2.33.13</version>
     </dependency>
 
     <dependency>
       <groupId>com.epimorphics</groupId>
       <artifactId>appbase</artifactId>
-      <version>3.1.14</version>
-    </dependency>
-   
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <version>${appbase.version}</version>
     </dependency>
 
     <dependency>
-        <groupId>org.glassfish.jersey.containers</groupId>
-        <!-- if your container implements Servlet API older than 3.0, use "jersey-container-servlet-core"  -->
-        <artifactId>jersey-container-servlet</artifactId>
-        <version>2.47</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <!-- if your container implements Servlet API older than 3.0, use "jersey-container-servlet-core"  -->
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.20</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.3</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
 
-     <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>
-        <version>1.8</version>
+        <version>1.9.5</version>
         <configuration>
           <connectionType>developerConnection</connectionType>
         </configuration>
@@ -154,45 +162,49 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.5.3</version>
       </plugin>
-
     </plugins>
 
     <extensions>
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-ftp</artifactId>
-        <version>2.6</version>
+        <version>2.12</version>
       </extension>
-      
+
       <extension>
         <groupId>org.springframework.build</groupId>
         <artifactId>aws-maven</artifactId>
         <version>5.0.0.RELEASE</version>
-      <!-- 
-        <groupId>org.springframework.build.aws</groupId>  
-        <artifactId>org.springframework.build.aws.maven</artifactId>  
-        <version>3.0.0.RELEASE</version>          
-         -->
       </extension>
-
     </extensions>
   </build>
 
   <distributionManagement>
-     <repository>  
-         <id>epi-public-s3-release</id>  
-         <name>Epimorphics S3 release repository</name>  
-         <url>s3://epi-repository/release</url>  
-     </repository>
-       
-     <snapshotRepository>  
-         <id>epi-public-s3-snapshot</id>  
-         <name>Epimorphics S3 snapshot repository</name>  
-         <url>s3://epi-repository/snapshot</url>  
-     </snapshotRepository>  
- 
+    <repository>
+      <id>epi-public-s3-release</id>
+      <name>Epimorphics S3 release repository</name>
+      <url>s3://epi-repository/release</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+
+    <snapshotRepository>
+      <id>epi-public-s3-snapshot</id>
+      <name>Epimorphics S3 snapshot repository</name>
+      <url>s3://epi-repository/snapshot</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </snapshotRepository>
   </distributionManagement>
 
 </project>

--- a/src/test/java/com/epimorphics/armlib/TestBatchRequest.java
+++ b/src/test/java/com/epimorphics/armlib/TestBatchRequest.java
@@ -2,22 +2,18 @@
  * File:        TestBatchRequest.java
  * Created by:  Dave Reynolds
  * Created on:  11 Nov 2015
- * 
+ *
  * (c) Copyright 2015, Epimorphics Limited
  *
  *****************************************************************/
 
 package com.epimorphics.armlib;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-
-import javax.ws.rs.core.MultivaluedMap;
-
+import jakarta.ws.rs.core.MultivaluedMap;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class TestBatchRequest {
 
@@ -28,33 +24,33 @@ public class TestBatchRequest {
         parameters.add("key1", "value2");
         parameters.add("key2", "value3");
         BatchRequest request = new BatchRequest("http://localhost/service", parameters);
-        
+
         String paramString = request.getParameterString();
-        assertTrue( paramString.contains("key1=value1") );
-        assertTrue( paramString.contains("key1=value2") );
-        assertTrue( paramString.contains("key2=value3") );
-        
+        assertTrue(paramString.contains("key1=value1"));
+        assertTrue(paramString.contains("key1=value2"));
+        assertTrue(paramString.contains("key2=value3"));
+
         assertEquals("http://localhost/service", request.getRequestURI());
         assertEquals("value3", request.getParameters().getFirst("key2"));
         String key = request.getKey();
         assertNotNull(key);
-        assertTrue( key.length() <= 800);
-        
+        assertTrue(key.length() <= 800);
+
         request.setKey("NewKey");
         assertEquals("NewKey", request.getKey());
-        
+
         parameters.add("key2", "value4");
         String keyOther = new BatchRequest("http://localhost/service", parameters).getKey();
         assertNotSame(key, keyOther);
-        
+
         parameters.addFirst("key3", null);    // Just parameter no value
-        assertTrue( parameters.containsKey("key3") );
-        
+        assertTrue(parameters.containsKey("key3"));
+
         request = new BatchRequest("http://localhost/service", parameters);
         String enc = request.getParameterString();
-        MultivaluedMap<String, String> recovered = BatchRequest.decodeParameterString( enc );
-        
+        MultivaluedMap<String, String> recovered = BatchRequest.decodeParameterString(enc);
+
         assertEquals(parameters, recovered);
-        
+
     }
 }

--- a/src/test/java/com/epimorphics/armlib/TestRequestManager.java
+++ b/src/test/java/com/epimorphics/armlib/TestRequestManager.java
@@ -2,19 +2,24 @@
  * File:        TestRequestManager.java
  * Created by:  Dave Reynolds
  * Created on:  17 Nov 2015
- * 
+ *
  * (c) Copyright 2015, Epimorphics Limited
  *
  *****************************************************************/
 
 package com.epimorphics.armlib;
 
-import static com.epimorphics.armlib.impl.DynQueueManager.COMPLETED_TIME_INDEX;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import com.epimorphics.armlib.BatchStatus.StatusFlag;
+import com.epimorphics.armlib.impl.*;
+import com.epimorphics.util.FileUtil;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.apache.jena.util.FileManager;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.Ignore;
+import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,29 +29,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
-import javax.ws.rs.core.MultivaluedMap;
-
-import org.apache.jena.util.FileManager;
-import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
-import org.junit.Ignore;
-import org.junit.Test;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
-import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
-
-import com.epimorphics.armlib.BatchStatus.StatusFlag;
-import com.epimorphics.armlib.impl.DynQueueManager;
-import com.epimorphics.armlib.impl.FileCacheManager;
-import com.epimorphics.armlib.impl.MemQueueManager;
-import com.epimorphics.armlib.impl.S3CacheManager;
-import com.epimorphics.armlib.impl.StandardRequestManager;
-import com.epimorphics.util.FileUtil;
+import static com.epimorphics.armlib.impl.DynQueueManager.COMPLETED_TIME_INDEX;
+import static org.junit.Assert.*;
 
 /**
  * Generic test for request managers. Can be configured to run
  * AWS based versions as well but default release testing uses
  * test implementations.
- * 
+ *
  * @author <a href="mailto:dave@epimorphics.com">Dave Reynolds</a>
  */
 public class TestRequestManager {
@@ -56,42 +46,42 @@ public class TestRequestManager {
         doLocalTest(false);
         doLocalTest(true);
     }
-    
+
     protected void doLocalTest(boolean compress) throws IOException, InterruptedException {
         FileCacheManager cache = new FileCacheManager();
         String testDir = Files.createTempDirectory("testmonitor").toFile().getPath();
-        cache.setCacheDir( testDir );
+        cache.setCacheDir(testDir);
         cache.setCompressed(compress);
 
         MemQueueManager queue = new MemQueueManager();
         queue.setCheckInterval(5);
-        
+
         doTestStandardRequestManager(queue, cache);
         FileUtil.deleteDirectory(testDir);
     }
-    
+
     // Test requires local instance of DynamoDB running on port 8000
     @Ignore
     @Test
     public void testWithDyn() throws IOException, InterruptedException {
         FileCacheManager cache = new FileCacheManager();
         String testDir = Files.createTempDirectory("testmonitor").toFile().getPath();
-        cache.setCacheDir( testDir );
+        cache.setCacheDir(testDir);
 
         DynQueueManager queue = new DynQueueManager();
         queue.setCheckInterval(100);
         queue.setLocalTestEndpoint("http://localhost:8000");
         queue.setTablePrefix("Test-");
         queue.startup(null);
-        
+
         doTestStandardRequestManager(queue, cache);
         addCompletedRequest(queue, 1);
         assertEquals(2, countCompleted(queue));
         long cutoff = System.currentTimeMillis();
-    
+
         addCompletedRequest(queue, 3);
         assertEquals(3, countCompleted(queue));
-        
+
         queue.removeOldCompletedRequests(cutoff);
         assertEquals(1, countCompleted(queue));
     }
@@ -101,21 +91,21 @@ public class TestRequestManager {
         queue.submit(request);
         queue.finishRequest(request.getKey());
     }
-    
+
     private int countCompleted(DynQueueManager queue) {
         ScanResponse result = queue.getDynamoClient().scan(ScanRequest.builder()
                 .tableName(queue.getCompletedTableName())
                 .indexName(COMPLETED_TIME_INDEX)
                 .build());
         int count = 0;
-        for (Map<String,AttributeValue> item : result.items()) {
+        for (Map<String, AttributeValue> item : result.items()) {
             if (item.get("Status").s().equals(StatusFlag.Completed.name())) {
                 count++;
             }
         }
         return count;
     }
-    
+
     // Test requires credentials and default profile for access to aws-expt
     @Ignore
     @Test
@@ -126,35 +116,35 @@ public class TestRequestManager {
 
         MemQueueManager queue = new MemQueueManager();
         queue.setCheckInterval(5);
-        
+
         doTestStandardRequestManager(queue, cm);
         cm.clear();
     }
-    
-    protected static void doTestStandardRequestManager(QueueManager qm, CacheManager cm)  throws InterruptedException, IOException {
+
+    protected static void doTestStandardRequestManager(QueueManager qm, CacheManager cm) throws InterruptedException, IOException {
         StandardRequestManager rm = new StandardRequestManager();
         rm.setCacheManager(cm);
         rm.setQueueManager(qm);
-        
+
         // Empty queue
-        assertNull( qm.nextRequest(12) );
-        
+        assertNull(qm.nextRequest(12));
+
         // Request not present in empty queue
         BatchRequest req1 = request("/test1", false, "p", "foo", "q", "bar");
         req1.setEstimatedTime(100);
-        assertNull( rm.findRequest(req1.getKey()) );
-        BatchStatus s1 = rm.getStatus( req1.getKey() );
-        assertNotNull( s1 );
+        assertNull(rm.findRequest(req1.getKey()));
+        BatchStatus s1 = rm.getStatus(req1.getKey());
+        assertNotNull(s1);
         assertEquals(StatusFlag.Unknown, s1.getStatus());
-        
+
         // Submit request and then its visible
         s1 = rm.submit(req1);
         assertEquals(StatusFlag.Pending, s1.getStatus());
-        s1 = rm.getStatus( req1.getKey() );
+        s1 = rm.getStatus(req1.getKey());
         assertEquals(StatusFlag.Pending, s1.getStatus());
-        
+
         // Request parameter order can vary
-        BatchRequest req1b = rm.findRequest( request("/test1", true, "q", "bar", "p", "foo").getKey() );
+        BatchRequest req1b = rm.findRequest(request("/test1", true, "q", "bar", "p", "foo").getKey());
         assertEquals(req1.getRequestURI(), req1b.getRequestURI());
         assertEquals(req1.getParameters(), req1b.getParameters());
 
@@ -164,86 +154,86 @@ public class TestRequestManager {
         rm.submit(req2);
         BatchStatus s2 = rm.getFullStatus(req2.getKey());
         assertEquals(StatusFlag.Pending, s2.getStatus());
-        assertEquals(150, (long)s2.getEta().get());
-        assertEquals(2, (int)s2.getPositionInQueue().get());
+        assertEquals(150, (long) s2.getEta().get());
+        assertEquals(2, (int) s2.getPositionInQueue().get());
 
         // Queue summary looks right
         checkQueue(rm, req1.getKey(), StatusFlag.Pending, req2.getKey(), StatusFlag.Pending);
-        
+
         // Nothing in the cache yet for either
-        assertFalse( cm.isReady( req1.getKey() ) );
-        assertFalse( cm.isReady( req2.getKey() ) );
-        
+        assertFalse(cm.isReady(req1.getKey()));
+        assertFalse(cm.isReady(req2.getKey()));
+
         // Start one request and that changes its state
         long start1 = System.currentTimeMillis();
         BatchRequest next = qm.nextRequest(12);
         long start2 = System.currentTimeMillis();
-        assertNotNull( next );
+        assertNotNull(next);
         assertEquals(req1.getRequestURI(), next.getRequestURI());
         checkQueue(rm, req1.getKey(), StatusFlag.InProgress, req2.getKey(), StatusFlag.Pending);
-        s1 = rm.getStatus( req1.getKey() );
-        assertTrue( s1.getStarted().isPresent() );
-        assertTrue( s1.getStarted().get() >= start1 );
-        assertTrue( s1.getStarted().get() <= start2 );
+        s1 = rm.getStatus(req1.getKey());
+        assertTrue(s1.getStarted().isPresent());
+        assertTrue(s1.getStarted().get() >= start1);
+        assertTrue(s1.getStarted().get() <= start2);
 
         // Put it back and try again
-        qm.abortRequest( next.getKey() );
+        qm.abortRequest(next.getKey());
         checkQueue(rm, req1.getKey(), StatusFlag.Pending, req2.getKey(), StatusFlag.Pending);
         next = qm.nextRequest(12);
         assertEquals(req1.getRequestURI(), next.getRequestURI());
         checkQueue(rm, req1.getKey(), StatusFlag.InProgress, req2.getKey(), StatusFlag.Pending);
-        
+
         // Generate a dummy result for the request and finish it
         Pipe pipe = cm.upload(next);
         OutputStream out = pipe.getSource();
-        out.write( "Test1 result".getBytes() );
+        out.write("Test1 result".getBytes());
         out.close();
         pipe.waitForCompletion();
         qm.finishRequest(next.getKey());
         checkQueue(rm, req2.getKey(), StatusFlag.Pending);
         s2 = rm.getFullStatus(req2.getKey());
-        assertEquals(50, (long)s2.getEta().get());
-        assertEquals(1, (int)s2.getPositionInQueue().get());
-        assertEquals(StatusFlag.Completed, rm.getStatus( req1.getKey() ).getStatus());
-        
+        assertEquals(50, (long) s2.getEta().get());
+        assertEquals(1, (int) s2.getPositionInQueue().get());
+        assertEquals(StatusFlag.Completed, rm.getStatus(req1.getKey()).getStatus());
+
         // Cache sees it OK
-        assertTrue( cm.isReady( req1.getKey() ) );
-        InputStream in = cm.readResult( req1.getKey() );
+        assertTrue(cm.isReady(req1.getKey()));
+        InputStream in = cm.readResult(req1.getKey());
         if (cm.isCompressed()) {
             in = new GZIPInputStream(in);
         }
-        String value = FileManager.get().readWholeFileAsUTF8( in );
-        assertEquals( "Test1 result", value);
-        
+        String value = FileManager.get().readWholeFileAsUTF8(in);
+        assertEquals("Test1 result", value);
+
         // Get next request but fail it
         next = qm.nextRequest(12);
         s2 = rm.getFullStatus(req2.getKey());
-        assertEquals(0, (int)s2.getPositionInQueue().get());
+        assertEquals(0, (int) s2.getPositionInQueue().get());
         assertEquals(StatusFlag.InProgress, s2.getStatus());
         assertEquals(req2.getKey(), next.getKey());
-        qm.failRequest( next.getKey() );
-        assertTrue ( rm.getQueue().isEmpty() );
+        qm.failRequest(next.getKey());
+        assertTrue(rm.getQueue().isEmpty());
         s2 = rm.getFullStatus(req2.getKey());
         assertEquals(StatusFlag.Failed, s2.getStatus());
     }
-    
-    private static BatchRequest request(String url, boolean sticky, String...args) {
+
+    private static BatchRequest request(String url, boolean sticky, String... args) {
         MultivaluedMap<String, String> parameters = new MultivaluedStringMap();
-        for (int i = 0; i < args.length;) {
+        for (int i = 0; i < args.length; ) {
             String key = args[i++];
             String value = args[i++];
             parameters.add(key, value);
         }
         return new BatchRequest(url, parameters, sticky);
     }
-    
-    private static void checkQueue(RequestManager rm, Object...args) {
+
+    private static void checkQueue(RequestManager rm, Object... args) {
         List<BatchStatus> queue = rm.getQueue();
-        assertEquals(args.length/2, queue.size());
-        for (int i = 0; i < args.length;) {
-            BatchStatus status = queue.get( i/2 );
-            String key = (String)args[i++];
-            StatusFlag s = (StatusFlag)args[i++];
+        assertEquals(args.length / 2, queue.size());
+        for (int i = 0; i < args.length; ) {
+            BatchStatus status = queue.get(i / 2);
+            String key = (String) args[i++];
+            StatusFlag s = (StatusFlag) args[i++];
             assertEquals(key, status.getKey());
             assertEquals(s, status.getStatus());
         }


### PR DESCRIPTION
JVM 1.8 -> 21
appbase 3.1.14 -> 4.0.0-SNAPSHOT
javax.servlet-api 3.1.0 -> jakarta.servlet-api 6.0.0
jersey-container-servlet 2.47 -> 3.1.11
Add logback-classic as logging provider
Update imports for javax -> jakarta migration
Replace use of StringBuffer with StringBuilder
Tidy-up source file formatting

QUESTION: Should we further bump to Jakarta EE 11? This would mean going to servlet-api 6.1 and jersey 4 which I did do for ELDA, but there might be more far-reaching implications here?