### PR TITLE
Bump netty-codec-http 4.1.129.Final to 4.1.132.Final to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
       <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
-          <version>4.1.129.Final</version>
+          <version>4.1.132.Final</version>
       </dependency>
 
     <dependency>


### PR DESCRIPTION
An FYI pull request to address the recent dependabot alert.